### PR TITLE
add client and client_url to pagerduty incidents

### DIFF
--- a/sentry_pagerduty/plugin.py
+++ b/sentry_pagerduty/plugin.py
@@ -51,4 +51,4 @@ class PagerDutyPlugin(NotifyPlugin):
         }
 
         client = pygerduty.PagerDuty(domain_name, api_key)
-        client.trigger_incident(service_key, description, details=details)
+        client.trigger_incident(service_key, description, details=details, client='sentry', client_url=group.get_absolute_url())


### PR DESCRIPTION
These values are used in the PagerDuty API and are currently null for events triggered via the Sentry integration. Sends `client` as `sentry` and `client_url` as the sentry url for the triggering issue.
