### PR TITLE
Do not create a new incident if one is already open

### DIFF
--- a/sentry_pagerduty/plugin.py
+++ b/sentry_pagerduty/plugin.py
@@ -51,4 +51,4 @@ class PagerDutyPlugin(NotifyPlugin):
         }
 
         client = pygerduty.PagerDuty(domain_name, api_key)
-        client.trigger_incident(service_key, description, details=details, client='sentry', client_url=group.get_absolute_url())
+        client.trigger_incident(service_key, description, incident_key=group.id, details=details, client='sentry', client_url=group.get_absolute_url())


### PR DESCRIPTION
Use the `incident_key` attribute on an event (https://developer.pagerduty.com/documentation/integration/events/trigger)
